### PR TITLE
Adding the ability to offset the reference from the target device pose.

### DIFF
--- a/OpenVR-SpaceCalibrator/Calibration.cpp
+++ b/OpenVR-SpaceCalibrator/Calibration.cpp
@@ -12,7 +12,6 @@
 
 static IPCClient Driver;
 CalibrationContext CalCtx;
-Pose ReferencePose;
 CalibrationState LastState = CalibrationState::None;
 
 void InitCalibrator()
@@ -37,6 +36,8 @@ struct Pose
 	}
 	Pose(double x, double y, double z) : trans(Eigen::Vector3d(x,y,z)) { }
 };
+
+Pose ReferencePose;
 
 struct Sample
 {

--- a/OpenVR-SpaceCalibrator/Calibration.cpp
+++ b/OpenVR-SpaceCalibrator/Calibration.cpp
@@ -405,13 +405,12 @@ void CalibrationTick(double time)
 
 	if (ctx.state == CalibrationState::Referencing)
 	{
-		Pose pose = Pose(ctx.devicePoses[ctx.targetID].mDeviceToAbsoluteTracking);
+		Pose pose(ctx.devicePoses[ctx.targetID].mDeviceToAbsoluteTracking);
 		if (ctx.state != LastState) {
 			ReferencePose = pose;
 		}
 		Eigen::Vector3d deltaTrans = pose.trans - ReferencePose.trans;
 		Eigen::Matrix3d deltaRot = pose.rot - ReferencePose.rot;
-		protocol::Request req(protocol::RequestSetDeviceTransform);
 		ctx.calibratedTranslation = ReferencePose.trans + deltaTrans;
 		ctx.calibratedRotation =  (ReferencePose.rot + deltaRot).eulerAngles(2, 1, 0) * 180.0 / EIGEN_PI;
 		ctx.wantedUpdateInterval = 0.1;

--- a/OpenVR-SpaceCalibrator/Calibration.h
+++ b/OpenVR-SpaceCalibrator/Calibration.h
@@ -11,6 +11,7 @@ enum class CalibrationState
 	Rotation,
 	Translation,
 	Editing,
+	Referencing
 };
 
 struct CalibrationContext
@@ -26,6 +27,7 @@ struct CalibrationContext
 
 	bool enabled = false;
 	bool validProfile = false;
+	bool isReferenceTracking = false;
 	double timeLastTick = 0, timeLastScan = 0;
 	double wantedUpdateInterval = 1.0;
 

--- a/OpenVR-SpaceCalibrator/Calibration.h
+++ b/OpenVR-SpaceCalibrator/Calibration.h
@@ -27,7 +27,6 @@ struct CalibrationContext
 
 	bool enabled = false;
 	bool validProfile = false;
-	bool isReferenceTracking = false;
 	double timeLastTick = 0, timeLastScan = 0;
 	double wantedUpdateInterval = 1.0;
 

--- a/OpenVR-SpaceCalibrator/OpenVR-SpaceCalibrator.vcxproj
+++ b/OpenVR-SpaceCalibrator/OpenVR-SpaceCalibrator.vcxproj
@@ -96,7 +96,6 @@
   <ItemGroup>
     <ClCompile Include="..\lib\gl3w\src\gl3w.c">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\lib\imgui\imgui.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>

--- a/OpenVR-SpaceCalibrator/OpenVR-SpaceCalibrator.vcxproj
+++ b/OpenVR-SpaceCalibrator/OpenVR-SpaceCalibrator.vcxproj
@@ -96,6 +96,7 @@
   <ItemGroup>
     <ClCompile Include="..\lib\gl3w\src\gl3w.c">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\lib\imgui\imgui.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>

--- a/OpenVR-SpaceCalibrator/UserInterface.cpp
+++ b/OpenVR-SpaceCalibrator/UserInterface.cpp
@@ -165,6 +165,17 @@ void BuildMenu(bool runningInOverlay)
 			SaveProfile(CalCtx);
 			CalCtx.state = CalibrationState::None;
 		}
+
+		if (CalCtx.state != CalibrationState::Referencing && ImGui::Button("Reference Offset", ImVec2(ImGui::GetWindowContentRegionWidth(), ImGui::GetTextLineHeight() * 2)))
+		{
+			CalCtx.state = CalibrationState::Referencing;
+		}
+
+		if (CalCtx.state == CalibrationState::Referencing && ImGui::Button("Stop Reference Offset", ImVec2(ImGui::GetWindowContentRegionWidth(), ImGui::GetTextLineHeight() * 2)))
+		{
+			SaveProfile(CalCtx);
+			CalCtx.state = CalibrationState::None;
+		}
 	}
 	else
 	{


### PR DESCRIPTION
This is not tested or complete yet, please don't merge this!

I have added a new UI button that allows you to enable "reference calibration" which is where it uses the target pose to update the tracking space translation/rotation. The hope is that I can use the grip on the target controller to achieve this but for now this is using a UI button to toggle the reference tracking. It is intended to save the pose when you enable reference tracking and then set the tracking position to be the delta from that until disabled, or until the grip is released when i implement that bit. 