### PR TITLE
Adding the ability to offset the reference from the target device pose.

### DIFF
--- a/OpenVR-SpaceCalibrator/Calibration.cpp
+++ b/OpenVR-SpaceCalibrator/Calibration.cpp
@@ -370,11 +370,6 @@ void StartCalibration()
 	CalCtx.messages.clear();
 }
 
-char* GetReferenceTrans() {
-	snprintf(ReferenceBuf, sizeof ReferenceBuf, "Refference offset point: %.8f %.8f %.8f\n", ReferenceTranslation(0), ReferenceTranslation(1), ReferenceTranslation(2));
-	return ReferenceBuf;
-}
-
 void SetReferenceOffset() {
 	auto &ctx = CalCtx;
 	Pose pose(ctx.devicePoses[ctx.referenceID].mDeviceToAbsoluteTracking);

--- a/OpenVR-SpaceCalibrator/Calibration.cpp
+++ b/OpenVR-SpaceCalibrator/Calibration.cpp
@@ -12,7 +12,6 @@
 
 static IPCClient Driver;
 CalibrationContext CalCtx;
-Pose ReferencePose;
 CalibrationState LastState = CalibrationState::None;
 
 void InitCalibrator()
@@ -37,6 +36,8 @@ struct Pose
 	}
 	Pose(double x, double y, double z) : trans(Eigen::Vector3d(x,y,z)) { }
 };
+
+Pose ReferencePose;
 
 struct Sample
 {

--- a/OpenVR-SpaceCalibrator/Calibration.cpp
+++ b/OpenVR-SpaceCalibrator/Calibration.cpp
@@ -405,13 +405,12 @@ void CalibrationTick(double time)
 
 	if (ctx.state == CalibrationState::Referencing)
 	{
-		Pose pose = Pose(ctx.devicePoses[ctx.targetID].mDeviceToAbsoluteTracking);
+		Pose pose(ctx.devicePoses[ctx.targetID].mDeviceToAbsoluteTracking);
 		if (ctx.state != LastState) {
 			ReferencePose = pose;
 		}
 		Eigen::Vector3d deltaTrans = pose.trans - ReferencePose.trans;
 		Eigen::Matrix3d deltaRot = pose.rot - ReferencePose.rot;
-		protocol::Request req(protocol::RequestSetDeviceTransform);
 		ctx.calibratedTranslation = ReferencePose.trans + deltaTrans;
 		ctx.calibratedRotation =  (ReferencePose.rot + deltaRot).eulerAngles(2, 1, 0) * 180.0 / EIGEN_PI;
 		ctx.wantedUpdateInterval = 0.1;

--- a/OpenVR-SpaceCalibrator/Calibration.cpp
+++ b/OpenVR-SpaceCalibrator/Calibration.cpp
@@ -413,13 +413,13 @@ void CalibrationTick(double time)
 		return;
 	}
 
-
 	if (ctx.state == CalibrationState::Referencing)
 	{
 		Pose pose(ctx.devicePoses[ctx.referenceID].mDeviceToAbsoluteTracking);
 		Eigen::Vector3d deltaTrans = pose.trans - ReferencePose.trans;
-		//Eigen::Matrix3d deltaRot = pose.rot - ReferencePose.rot;
-		ctx.calibratedTranslation = ReferenceTranslation + (deltaTrans * 100);
+		ctx.calibratedTranslation = (ReferenceTranslation + (deltaTrans * 100));
+
+		// Attempt # 1, getting teh euler delta and adding it to the original reference rotation - does not work.
 		//auto rotation = pose.rot.eulerAngles(2, 1, 0) * 180.0 / EIGEN_PI;
 		/*ctx.calibratedRotation[0] = ReferenceRotation(0) + rotation(0);
 		ctx.calibratedRotation[1] = ReferenceRotation(1) + rotation(1);
@@ -427,6 +427,23 @@ void CalibrationTick(double time)
 		//ctx.calibratedRotation[0] = rotation(0);
 		//ctx.calibratedRotation[1] = rotation(1);
 		//ctx.calibratedRotation[2] = rotation(2);
+
+
+		// Attempt #2, convert it all to quaternions ?? didnt get far with this one.
+		/*Eigen::Quaterniond currentQuat =
+			Eigen::AngleAxisd(ctx.calibratedRotation(0), Eigen::Vector3d::UnitZ()) *
+			Eigen::AngleAxisd(ctx.calibratedRotation(1), Eigen::Vector3d::UnitY()) *
+			Eigen::AngleAxisd(ctx.calibratedRotation(2), Eigen::Vector3d::UnitX());
+		Eigen::Matrix3d deltaRot = pose.rot - ReferencePose.rot;
+		Eigen::Quaternionf delta(deltaRot);
+		vr::HmdQuaternion_t deltaQuat;
+		deltaQuat.x = delta.coeffs()[0];
+		deltaQuat.y = delta.coeffs()[1];
+		deltaQuat.z = delta.coeffs()[2];
+		deltaQuat.w = delta.coeffs()[3];*/
+		//currentQuat.normalize();
+		// Eigen::Matrix3d updatedRot = currentQuat.toRotationMatrix() + deltaRot;
+
 
 		ctx.wantedUpdateInterval = 0.025;
 

--- a/OpenVR-SpaceCalibrator/Calibration.cpp
+++ b/OpenVR-SpaceCalibrator/Calibration.cpp
@@ -416,11 +416,11 @@ void CalibrationTick(double time)
 		}
 		Eigen::Vector3d deltaTrans = pose.trans - ReferencePose.trans;
 		Eigen::Matrix3d deltaRot = pose.rot - ReferencePose.rot;
-		ctx.calibratedTranslation = ReferenceTranslation + deltaTrans;
-		ctx.calibratedRotation = ReferenceRotation + AxisFromRotationMatrix3(deltaRot);
-		ctx.wantedUpdateInterval = 0.1;
+		ctx.calibratedTranslation = ReferencePose.trans + deltaTrans;
+		ctx.calibratedRotation = AxisFromRotationMatrix3(ReferencePose.rot + deltaRot);
+		ctx.wantedUpdateInterval = 0.05;
 
-		if ((time - ctx.timeLastScan) >= 0.1)
+		if ((time - ctx.timeLastScan) >= 0.05)
 		{
 			ScanAndApplyProfile(ctx);
 			ctx.timeLastScan = time;

--- a/OpenVR-SpaceCalibrator/Calibration.cpp
+++ b/OpenVR-SpaceCalibrator/Calibration.cpp
@@ -15,7 +15,6 @@ CalibrationContext CalCtx;
 CalibrationState LastState = CalibrationState::None;
 Eigen::Vector3d ReferenceTranslation;
 Eigen::Vector3d ReferenceRotation;
-char ReferenceBuf[256];
 
 void InitCalibrator()
 {

--- a/OpenVR-SpaceCalibrator/Calibration.h
+++ b/OpenVR-SpaceCalibrator/Calibration.h
@@ -29,6 +29,7 @@ struct CalibrationContext
 	bool validProfile = false;
 	double timeLastTick = 0, timeLastScan = 0;
 	double wantedUpdateInterval = 1.0;
+	char ButtonBuf[1024];
 
 	enum Speed
 	{
@@ -100,7 +101,7 @@ struct CalibrationContext
 			messages.push_back(Message(Message::String));
 
 		messages.back().str += msg;
-		// std::cerr << msg;
+		std::cerr << msg;
 	}
 
 	void Progress(int current, int target)

--- a/OpenVR-SpaceCalibrator/Calibration.h
+++ b/OpenVR-SpaceCalibrator/Calibration.h
@@ -11,6 +11,7 @@ enum class CalibrationState
 	Rotation,
 	Translation,
 	Editing,
+	Referencing
 };
 
 struct CalibrationContext
@@ -26,6 +27,7 @@ struct CalibrationContext
 
 	bool enabled = false;
 	bool validProfile = false;
+	bool isReferenceTracking = false;
 	double timeLastTick = 0, timeLastScan = 0;
 	double wantedUpdateInterval = 1.0;
 

--- a/OpenVR-SpaceCalibrator/Calibration.h
+++ b/OpenVR-SpaceCalibrator/Calibration.h
@@ -29,7 +29,6 @@ struct CalibrationContext
 	bool validProfile = false;
 	double timeLastTick = 0, timeLastScan = 0;
 	double wantedUpdateInterval = 1.0;
-	char ButtonBuf[1024];
 
 	enum Speed
 	{
@@ -122,4 +121,3 @@ void StartCalibration();
 void LoadChaperoneBounds();
 void ApplyChaperoneBounds();
 void SetReferenceOffset();
-char* GetReferenceTrans();

--- a/OpenVR-SpaceCalibrator/Calibration.h
+++ b/OpenVR-SpaceCalibrator/Calibration.h
@@ -27,7 +27,6 @@ struct CalibrationContext
 
 	bool enabled = false;
 	bool validProfile = false;
-	bool isReferenceTracking = false;
 	double timeLastTick = 0, timeLastScan = 0;
 	double wantedUpdateInterval = 1.0;
 

--- a/OpenVR-SpaceCalibrator/Calibration.h
+++ b/OpenVR-SpaceCalibrator/Calibration.h
@@ -100,7 +100,7 @@ struct CalibrationContext
 			messages.push_back(Message(Message::String));
 
 		messages.back().str += msg;
-		std::cerr << msg;
+		// std::cerr << msg;
 	}
 
 	void Progress(int current, int target)
@@ -120,3 +120,5 @@ void CalibrationTick(double time);
 void StartCalibration();
 void LoadChaperoneBounds();
 void ApplyChaperoneBounds();
+void SetReferenceOffset();
+char* GetReferenceTrans();

--- a/OpenVR-SpaceCalibrator/OpenVR-SpaceCalibrator.cpp
+++ b/OpenVR-SpaceCalibrator/OpenVR-SpaceCalibrator.cpp
@@ -237,26 +237,27 @@ void RunLoop()
 
 			vr::VREvent_t event;
 			while (vr::VRSystem()->PollNextEvent(&event, sizeof(event))) {
-				vr::VRControllerState_t state;
-				vr::VRSystem()->GetControllerState(CalCtx.referenceID, &state, sizeof(state));
-				bool pushed = (state.ulButtonPressed & vr::ButtonMaskFromId(vr::EVRButtonId::k_EButton_Grip)) != 0;
-				//snprintf(CalCtx.ButtonBuf, sizeof CalCtx.ButtonBuf, "VREvent_ButtonPress: %d\n", (state.ulButtonPressed & vr::ButtonMaskFromId(vr::EVRButtonId::k_EButton_A)));
+				if (event.eventType == vr::VREvent_ButtonPress || event.eventType == vr::VREvent_ButtonUnpress) {
+					vr::VRControllerState_t state;
+					vr::VRSystem()->GetControllerState(CalCtx.referenceID, &state, sizeof(state));
+					bool pushed = (state.ulButtonPressed & vr::ButtonMaskFromId(vr::EVRButtonId::k_EButton_Grip)) != 0;
+					//snprintf(CalCtx.ButtonBuf, sizeof CalCtx.ButtonBuf, "VREvent_ButtonPress: %d\n", (state.ulButtonPressed & vr::ButtonMaskFromId(vr::EVRButtonId::k_EButton_A)));
 
-				if (pushed) {
-					//snprintf(CalCtx.ButtonBuf, sizeof CalCtx.ButtonBuf, "pushed\n");
-					if (CalCtx.state == CalibrationState::Editing) {
-						SetReferenceOffset();
-						CalCtx.state = CalibrationState::Referencing;
+					if (pushed) {
+						//snprintf(CalCtx.ButtonBuf, sizeof CalCtx.ButtonBuf, "pushed\n");
+						if (CalCtx.state == CalibrationState::Editing) {
+							SetReferenceOffset();
+							CalCtx.state = CalibrationState::Referencing;
+						}
 					}
-				}else if(CalCtx.state == CalibrationState::Referencing){
-					SaveProfile(CalCtx);
-					CalCtx.state = CalibrationState::Editing;
+					else if (CalCtx.state == CalibrationState::Referencing) {
+						SaveProfile(CalCtx);
+						CalCtx.state = CalibrationState::Editing;
+					}
 				}
 			}
 
 			vr::VREvent_t vrEvent;
-			vr::VRControllerState_t state;
-			bool pushed = false;
 			while (vr::VROverlay()->PollNextOverlayEvent(overlayMainHandle, &vrEvent, sizeof(vrEvent)))
 			{
 				switch (vrEvent.eventType) {

--- a/OpenVR-SpaceCalibrator/OpenVR-SpaceCalibrator.cpp
+++ b/OpenVR-SpaceCalibrator/OpenVR-SpaceCalibrator.cpp
@@ -241,10 +241,8 @@ void RunLoop()
 					vr::VRControllerState_t state;
 					vr::VRSystem()->GetControllerState(CalCtx.referenceID, &state, sizeof(state));
 					bool pushed = (state.ulButtonPressed & vr::ButtonMaskFromId(vr::EVRButtonId::k_EButton_Grip)) != 0;
-					//snprintf(CalCtx.ButtonBuf, sizeof CalCtx.ButtonBuf, "VREvent_ButtonPress: %d\n", (state.ulButtonPressed & vr::ButtonMaskFromId(vr::EVRButtonId::k_EButton_A)));
-
+					
 					if (pushed) {
-						//snprintf(CalCtx.ButtonBuf, sizeof CalCtx.ButtonBuf, "pushed\n");
 						if (CalCtx.state == CalibrationState::Editing) {
 							SetReferenceOffset();
 							CalCtx.state = CalibrationState::Referencing;

--- a/OpenVR-SpaceCalibrator/OpenVR-SpaceCalibrator.cpp
+++ b/OpenVR-SpaceCalibrator/OpenVR-SpaceCalibrator.cpp
@@ -235,7 +235,28 @@ void RunLoop()
 				keyboardOpen = true;
 			}
 
+			vr::VREvent_t event;
+			while (vr::VRSystem()->PollNextEvent(&event, sizeof(event))) {
+				vr::VRControllerState_t state;
+				vr::VRSystem()->GetControllerState(CalCtx.referenceID, &state, sizeof(state));
+				bool pushed = (state.ulButtonPressed & vr::ButtonMaskFromId(vr::EVRButtonId::k_EButton_Grip)) != 0;
+				//snprintf(CalCtx.ButtonBuf, sizeof CalCtx.ButtonBuf, "VREvent_ButtonPress: %d\n", (state.ulButtonPressed & vr::ButtonMaskFromId(vr::EVRButtonId::k_EButton_A)));
+
+				if (pushed) {
+					//snprintf(CalCtx.ButtonBuf, sizeof CalCtx.ButtonBuf, "pushed\n");
+					if (CalCtx.state == CalibrationState::Editing) {
+						SetReferenceOffset();
+						CalCtx.state = CalibrationState::Referencing;
+					}
+				}else if(CalCtx.state == CalibrationState::Referencing){
+					SaveProfile(CalCtx);
+					CalCtx.state = CalibrationState::Editing;
+				}
+			}
+
 			vr::VREvent_t vrEvent;
+			vr::VRControllerState_t state;
+			bool pushed = false;
 			while (vr::VROverlay()->PollNextOverlayEvent(overlayMainHandle, &vrEvent, sizeof(vrEvent)))
 			{
 				switch (vrEvent.eventType) {

--- a/OpenVR-SpaceCalibrator/OpenVR-SpaceCalibrator.vcxproj
+++ b/OpenVR-SpaceCalibrator/OpenVR-SpaceCalibrator.vcxproj
@@ -96,7 +96,6 @@
   <ItemGroup>
     <ClCompile Include="..\lib\gl3w\src\gl3w.c">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\lib\imgui\imgui.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>

--- a/OpenVR-SpaceCalibrator/OpenVR-SpaceCalibrator.vcxproj
+++ b/OpenVR-SpaceCalibrator/OpenVR-SpaceCalibrator.vcxproj
@@ -96,6 +96,7 @@
   <ItemGroup>
     <ClCompile Include="..\lib\gl3w\src\gl3w.c">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\lib\imgui\imgui.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>

--- a/OpenVR-SpaceCalibrator/UserInterface.cpp
+++ b/OpenVR-SpaceCalibrator/UserInterface.cpp
@@ -165,6 +165,17 @@ void BuildMenu(bool runningInOverlay)
 			SaveProfile(CalCtx);
 			CalCtx.state = CalibrationState::None;
 		}
+
+		if (CalCtx.state != CalibrationState::Referencing && ImGui::Button("Reference Offset", ImVec2(ImGui::GetWindowContentRegionWidth(), ImGui::GetTextLineHeight() * 2)))
+		{
+			CalCtx.state = CalibrationState::Referencing;
+		}
+
+		if (CalCtx.state == CalibrationState::Referencing && ImGui::Button("Stop Reference Offset", ImVec2(ImGui::GetWindowContentRegionWidth(), ImGui::GetTextLineHeight() * 2)))
+		{
+			SaveProfile(CalCtx);
+			CalCtx.state = CalibrationState::None;
+		}
 	}
 	else
 	{

--- a/OpenVR-SpaceCalibrator/UserInterface.cpp
+++ b/OpenVR-SpaceCalibrator/UserInterface.cpp
@@ -156,7 +156,7 @@ void BuildMenu(bool runningInOverlay)
 
 		ImGui::Columns(1);
 	}
-	else if (CalCtx.state == CalibrationState::Editing)
+	else if (CalCtx.state == CalibrationState::Editing || CalCtx.state == CalibrationState::Referencing)
 	{
 		BuildProfileEditor();
 

--- a/OpenVR-SpaceCalibrator/UserInterface.cpp
+++ b/OpenVR-SpaceCalibrator/UserInterface.cpp
@@ -166,16 +166,14 @@ void BuildMenu(bool runningInOverlay)
 			CalCtx.state = CalibrationState::None;
 		}
 
-		if (CalCtx.state == CalibrationState::Referencing && ImGui::Button("Stop Reference Offset", ImVec2(ImGui::GetWindowContentRegionWidth(), ImGui::GetTextLineHeight() * 2)))
+		ImGui::Text("\n");
+		ImGui::Text("Close the steam menu to grab the target space and fine adjust with the reference grip button.\n");
+		ImGui::Text("When you let go it will save the profile.\n");
+		ImGui::Text("\n");
+
+		if (ImGui::Button("Back", ImVec2(ImGui::GetWindowContentRegionWidth(), ImGui::GetTextLineHeight() * 2)))
 		{
-			SaveProfile(CalCtx);
-			CalCtx.state = CalibrationState::Editing;
-		}
-		
-		if (CalCtx.state != CalibrationState::Referencing && ImGui::Button("Reference Offset", ImVec2(ImGui::GetWindowContentRegionWidth(), ImGui::GetTextLineHeight() * 2)))
-		{
-			SetReferenceOffset();
-			CalCtx.state = CalibrationState::Referencing;
+			CalCtx.state = CalibrationState::None;
 		}
 	}
 	else

--- a/OpenVR-SpaceCalibrator/UserInterface.cpp
+++ b/OpenVR-SpaceCalibrator/UserInterface.cpp
@@ -171,7 +171,7 @@ void BuildMenu(bool runningInOverlay)
 			SaveProfile(CalCtx);
 			CalCtx.state = CalibrationState::Editing;
 		}
-
+		
 		if (CalCtx.state != CalibrationState::Referencing && ImGui::Button("Reference Offset", ImVec2(ImGui::GetWindowContentRegionWidth(), ImGui::GetTextLineHeight() * 2)))
 		{
 			SetReferenceOffset();
@@ -179,6 +179,7 @@ void BuildMenu(bool runningInOverlay)
 		}
 		if (CalCtx.state == CalibrationState::Referencing) {
 			ImGui::TextWrapped(GetReferenceTrans());
+			ImGui::TextWrapped(CalCtx.ButtonBuf);
 		}
 	}
 	else

--- a/OpenVR-SpaceCalibrator/UserInterface.cpp
+++ b/OpenVR-SpaceCalibrator/UserInterface.cpp
@@ -166,15 +166,19 @@ void BuildMenu(bool runningInOverlay)
 			CalCtx.state = CalibrationState::None;
 		}
 
-		if (CalCtx.state != CalibrationState::Referencing && ImGui::Button("Reference Offset", ImVec2(ImGui::GetWindowContentRegionWidth(), ImGui::GetTextLineHeight() * 2)))
-		{
-			CalCtx.state = CalibrationState::Referencing;
-		}
-
 		if (CalCtx.state == CalibrationState::Referencing && ImGui::Button("Stop Reference Offset", ImVec2(ImGui::GetWindowContentRegionWidth(), ImGui::GetTextLineHeight() * 2)))
 		{
 			SaveProfile(CalCtx);
-			CalCtx.state = CalibrationState::None;
+			CalCtx.state = CalibrationState::Editing;
+		}
+
+		if (CalCtx.state != CalibrationState::Referencing && ImGui::Button("Reference Offset", ImVec2(ImGui::GetWindowContentRegionWidth(), ImGui::GetTextLineHeight() * 2)))
+		{
+			SetReferenceOffset();
+			CalCtx.state = CalibrationState::Referencing;
+		}
+		if (CalCtx.state == CalibrationState::Referencing) {
+			ImGui::TextWrapped(GetReferenceTrans());
 		}
 	}
 	else

--- a/OpenVR-SpaceCalibrator/UserInterface.cpp
+++ b/OpenVR-SpaceCalibrator/UserInterface.cpp
@@ -177,10 +177,6 @@ void BuildMenu(bool runningInOverlay)
 			SetReferenceOffset();
 			CalCtx.state = CalibrationState::Referencing;
 		}
-		if (CalCtx.state == CalibrationState::Referencing) {
-			ImGui::TextWrapped(GetReferenceTrans());
-			ImGui::TextWrapped(CalCtx.ButtonBuf);
-		}
 	}
 	else
 	{


### PR DESCRIPTION
This is not tested or complete yet, please don't merge this!

I have added a new UI button that allows you to enable "reference calibration" which is where it uses the target pose to update the tracking space translation/rotation. The hope is that I can use the grip on the target controller to achieve this but for now this is using a UI button to toggle the reference tracking. It is intended to save the pose when you enable reference tracking and then set the tracking position to be the delta from that until disabled, or until the grip is released when I implement that bit.