### PR TITLE
Ability to offset real world player vs VR avatar heights.

### DIFF
--- a/OpenVR-SpaceCalibrator/Calibration.h
+++ b/OpenVR-SpaceCalibrator/Calibration.h
@@ -37,6 +37,20 @@ struct CalibrationContext
 	};
 	Speed calibrationSpeed = FAST;
 
+	enum OffsetMode
+	{
+		OFFSETS_NONE = 0,
+		OFFSETS_2_DEVICE_HANDS = 1,
+		OFFSETS_4_DEVICE_HANDS = 2,
+	};
+	OffsetMode offsetsEnabled = OFFSETS_NONE;
+
+	float customScale = 1.0f;
+	float handsOffsetScale = 0.65f;
+	float hipOffsetScale = 1.1f;
+	float feetOffsetScale = 1.25f;
+
+
 	vr::TrackedDevicePose_t devicePoses[vr::k_unMaxTrackedDeviceCount];
 
 	struct Chaperone

--- a/OpenVR-SpaceCalibrator/UserInterface.cpp
+++ b/OpenVR-SpaceCalibrator/UserInterface.cpp
@@ -11,6 +11,9 @@
 
 #define VERSION_STRING "1.2"
 
+bool ENABLE_OFFSETS_2_DEVICE_HANDS = false;
+bool ENABLE_OFFSETS_4_DEVICE_HANDS = false;
+
 struct VRDevice
 {
 	int id = -1;
@@ -155,6 +158,101 @@ void BuildMenu(bool runningInOverlay)
 			CalCtx.calibrationSpeed = CalibrationContext::VERY_SLOW;
 
 		ImGui::Columns(1);
+
+		//
+		// UQ1: Offsets... TODO: These should really be saved, or have profiles for quick startup???
+		//
+		ImGui::Text("");
+		ImGui::Text("");
+		ImGui::Text("");
+		auto offsetMethod = CalCtx.offsetsEnabled;
+
+		ImGui::Text("Player Height Adjustment");
+		ImGui::Text("IMPORTANT: This system assumes you start devices in order:");
+		ImGui::Text(" 1. Hand controllers.");
+		ImGui::Text(" 2. Hip tracker.");
+		ImGui::Text(" 3. Feet trackers.");
+		ImGui::Text(" 4. Any other trackers (these will share the feet offsets - untested).");
+		ImGui::Text("");
+
+		ImGui::Text("Offsets");
+		ImGui::Text(" No Offsets - disables offsets");
+		ImGui::Text(" 2 Devices  - If your hardware uses 2 devices for hand controllers (Quest 2 using Virtual Desktop etc)");
+		ImGui::Text(" 4 Devices  - If your hardware uses 4 devices for hand controllers (Vive, etc)");
+		ImGui::Text("");
+		ImGui::Text("You can freely switch between these options to work out which is correct for your hardware without loosing setting changes below.");
+		ImGui::Text("");
+
+		ImGui::Columns(3, NULL, false);
+		/*
+		ImGui::Columns(4, NULL, false);
+		ImGui::Text("Offsets");
+
+		ImGui::NextColumn();
+		*/
+
+		if (ImGui::RadioButton(" No Offsets    ", offsetMethod == CalibrationContext::OFFSETS_NONE))
+			CalCtx.offsetsEnabled = CalibrationContext::OFFSETS_NONE;
+
+		ImGui::NextColumn();
+		if (ImGui::RadioButton(" 2 Devices     ", offsetMethod == CalibrationContext::OFFSETS_2_DEVICE_HANDS))
+			CalCtx.offsetsEnabled = CalibrationContext::OFFSETS_2_DEVICE_HANDS;
+
+		ImGui::NextColumn();
+		if (ImGui::RadioButton(" 4 Devices     ", offsetMethod == CalibrationContext::OFFSETS_4_DEVICE_HANDS))
+			CalCtx.offsetsEnabled = CalibrationContext::OFFSETS_4_DEVICE_HANDS;
+
+		ImGui::Text("");
+		ImGui::Columns(1);
+
+		ImGui::Text("");
+		auto offsetScale = CalCtx.customScale;
+
+		if (ImGui::DragFloat(" Scale         ", &offsetScale, 0.0001f, 0.001f, 2.000f, "%.3f", 1.0f))
+			CalCtx.customScale = offsetScale;
+
+		ImGui::Text("");
+		ImGui::Text("Fine Tune Custom Offsets");
+		ImGui::Text("These are strengths of offsets of each tracked body part type. Use these to customize as needed.");
+		auto handsOffsetScale = CalCtx.handsOffsetScale;
+		auto hipOffsetScale = CalCtx.hipOffsetScale;
+		auto feetOffsetScale = CalCtx.feetOffsetScale;
+
+		if (ImGui::DragFloat(" Hands ", &handsOffsetScale, 0.0001f, 0.001f, 2.000f, "%.3f", 1.0f))
+			CalCtx.handsOffsetScale = handsOffsetScale;
+
+		if (ImGui::DragFloat(" Hip   ", &hipOffsetScale, 0.0001f, 0.001f, 2.000f, "%.3f", 1.0f))
+			CalCtx.hipOffsetScale = hipOffsetScale;
+
+		if (ImGui::DragFloat(" Feet  ", &feetOffsetScale, 0.0001f, 0.001f, 2.000f, "%.3f", 1.0f))
+			CalCtx.feetOffsetScale = feetOffsetScale;
+
+		ImGui::Text("");
+
+		//
+		//
+		//
+		/*
+		ImGui::Text("");
+
+		char buffer[vr::k_unMaxPropertyStringSize];
+
+		for (uint32_t id = 0; id < vr::k_unMaxTrackedDeviceCount; ++id)
+		{
+			auto deviceClass = vr::VRSystem()->GetTrackedDeviceClass(id);
+			if (deviceClass == vr::TrackedDeviceClass_Invalid)
+				continue;
+
+			vr::ETrackedPropertyError err = vr::TrackedProp_Success;
+			vr::VRSystem()->GetStringTrackedDeviceProperty(id, vr::Prop_TrackingSystemName_String, buffer, vr::k_unMaxPropertyStringSize, &err);
+
+			if (err != vr::TrackedProp_Success)
+			{
+				continue;
+			}
+
+			ImGui::Text("Device %u - class %u\n", id, deviceClass);
+		}*/
 	}
 	else if (CalCtx.state == CalibrationState::Editing)
 	{


### PR DESCRIPTION
Ability to offset real world player vs VR avatar heights, for hands, hip, and feet trackers. It is fairly basic but functional.

I made the changes for my own needs, but i'm sure many other people would love this as input emulator is unsupported now and there is no other choice out there to do this. Space calibrator is also a lot less laggy then IE ever was.

Could use some enhancements like better UI, ability to load/save settings or profiles, maybe scale other axis to match, and probably other stuff, but as it is it works very well for me and greatly improves tracking quality with scale differences between player and avatar.
