### PR TITLE
Driver Scale Parameter

### DIFF
--- a/OpenVR-SpaceCalibrator/Calibration.cpp
+++ b/OpenVR-SpaceCalibrator/Calibration.cpp
@@ -269,7 +269,7 @@ void ResetAndDisableOffsets(uint32_t id)
 	zeroQ.x = 0; zeroQ.y = 0; zeroQ.z = 0; zeroQ.w = 1;
 
 	protocol::Request req(protocol::RequestSetDeviceTransform);
-	req.setDeviceTransform = { id, false, zeroV, zeroQ };
+	req.setDeviceTransform = { id, false, zeroV, zeroQ, 1.0 };
 	Driver.SendBlocking(req);
 }
 
@@ -338,7 +338,8 @@ void ScanAndApplyProfile(CalibrationContext &ctx)
 			id,
 			true,
 			VRTranslationVec(ctx.calibratedTranslation),
-			VRRotationQuat(ctx.calibratedRotation)
+			VRRotationQuat(ctx.calibratedRotation),
+			ctx.calibratedScale
 		};
 		Driver.SendBlocking(req);
 	}

--- a/OpenVR-SpaceCalibrator/Calibration.h
+++ b/OpenVR-SpaceCalibrator/Calibration.h
@@ -20,6 +20,7 @@ struct CalibrationContext
 
 	Eigen::Vector3d calibratedRotation;
 	Eigen::Vector3d calibratedTranslation;
+	double calibratedScale;
 
 	std::string referenceTrackingSystem;
 	std::string targetTrackingSystem;
@@ -57,6 +58,7 @@ struct CalibrationContext
 
 		calibratedRotation = Eigen::Vector3d();
 		calibratedTranslation = Eigen::Vector3d();
+		calibratedScale = 1.0;
 		referenceTrackingSystem = "";
 		targetTrackingSystem = "";
 		enabled = false;

--- a/OpenVR-SpaceCalibrator/Configuration.cpp
+++ b/OpenVR-SpaceCalibrator/Configuration.cpp
@@ -54,6 +54,11 @@ static void ParseProfile(CalibrationContext &ctx, std::istream &stream)
 	ctx.calibratedTranslation(1) = obj["y"].get<double>();
 	ctx.calibratedTranslation(2) = obj["z"].get<double>();
 
+	if (obj["scale"].is<double>())
+		ctx.calibratedScale = obj["scale"].get<double>();
+	else
+		ctx.calibratedScale = 1.0;
+
 	if (obj["calibration_speed"].is<double>())
 		ctx.calibrationSpeed = (CalibrationContext::Speed)(int) obj["calibration_speed"].get<double>();
 
@@ -101,6 +106,7 @@ static void WriteProfile(CalibrationContext &ctx, std::ostream &out)
 	profile["x"].set<double>(ctx.calibratedTranslation(0));
 	profile["y"].set<double>(ctx.calibratedTranslation(1));
 	profile["z"].set<double>(ctx.calibratedTranslation(2));
+	profile["scale"].set<double>(ctx.calibratedScale);
 
 	double speed = (int) ctx.calibrationSpeed;
 	profile["calibration_speed"].set<double>(speed);

--- a/OpenVR-SpaceCalibrator/UserInterface.cpp
+++ b/OpenVR-SpaceCalibrator/UserInterface.cpp
@@ -489,6 +489,10 @@ void BuildProfileEditor()
 	ImGui::InputDouble("##Y", &CalCtx.calibratedTranslation(1), 1.0, 10.0, "%.8f");
 	ImGui::SameLine();
 	ImGui::InputDouble("##Z", &CalCtx.calibratedTranslation(2), 1.0, 10.0, "%.8f");
+
+	TextWithWidth("ScaleLabel", "Scale", width);
+
+	ImGui::InputDouble("##Scale", &CalCtx.calibratedScale, 0.01, 0.1, "%.8f");
 	ImGui::PopItemWidth();
 }
 

--- a/OpenVR-SpaceCalibrator/UserInterface.cpp
+++ b/OpenVR-SpaceCalibrator/UserInterface.cpp
@@ -492,7 +492,7 @@ void BuildProfileEditor()
 
 	TextWithWidth("ScaleLabel", "Scale", width);
 
-	ImGui::InputDouble("##Scale", &CalCtx.calibratedScale, 0.01, 0.1, "%.8f");
+	ImGui::InputDouble("##Scale", &CalCtx.calibratedScale, 0.0001, 0.01, "%.8f");
 	ImGui::PopItemWidth();
 }
 

--- a/OpenVR-SpaceCalibratorDriver/ServerTrackedDeviceProvider.cpp
+++ b/OpenVR-SpaceCalibratorDriver/ServerTrackedDeviceProvider.cpp
@@ -61,10 +61,14 @@ bool ServerTrackedDeviceProvider::HandleDevicePoseUpdated(uint32_t openVRID, vr:
 	{
 		pose.qWorldFromDriverRotation = tf.rotation * pose.qWorldFromDriverRotation;
 
+		pose.vecPosition[0] *= tf.scale;
+		pose.vecPosition[1] *= tf.scale;
+		pose.vecPosition[2] *= tf.scale;
+
 		vr::HmdVector3d_t rotatedTranslation = quaternionRotateVector(tf.rotation, pose.vecWorldFromDriverTranslation);
-		pose.vecWorldFromDriverTranslation[0] = tf.scale * rotatedTranslation.v[0] + tf.translation.v[0];
-		pose.vecWorldFromDriverTranslation[1] = tf.scale * rotatedTranslation.v[1] + tf.translation.v[1];
-		pose.vecWorldFromDriverTranslation[2] = tf.scale * rotatedTranslation.v[2] + tf.translation.v[2];
+		pose.vecWorldFromDriverTranslation[0] = rotatedTranslation.v[0] + tf.translation.v[0];
+		pose.vecWorldFromDriverTranslation[1] = rotatedTranslation.v[1] + tf.translation.v[1];
+		pose.vecWorldFromDriverTranslation[2] = rotatedTranslation.v[2] + tf.translation.v[2];
 	}
 	return true;
 }

--- a/OpenVR-SpaceCalibratorDriver/ServerTrackedDeviceProvider.cpp
+++ b/OpenVR-SpaceCalibratorDriver/ServerTrackedDeviceProvider.cpp
@@ -49,6 +49,9 @@ void ServerTrackedDeviceProvider::SetDeviceTransform(const protocol::SetDeviceTr
 
 	if (newTransform.updateRotation)
 		tf.rotation = newTransform.rotation;
+
+	if (newTransform.updateScale)
+		tf.scale = newTransform.scale;
 }
 
 bool ServerTrackedDeviceProvider::HandleDevicePoseUpdated(uint32_t openVRID, vr::DriverPose_t &pose)
@@ -59,9 +62,9 @@ bool ServerTrackedDeviceProvider::HandleDevicePoseUpdated(uint32_t openVRID, vr:
 		pose.qWorldFromDriverRotation = tf.rotation * pose.qWorldFromDriverRotation;
 
 		vr::HmdVector3d_t rotatedTranslation = quaternionRotateVector(tf.rotation, pose.vecWorldFromDriverTranslation);
-		pose.vecWorldFromDriverTranslation[0] = rotatedTranslation.v[0] + tf.translation.v[0];
-		pose.vecWorldFromDriverTranslation[1] = rotatedTranslation.v[1] + tf.translation.v[1];
-		pose.vecWorldFromDriverTranslation[2] = rotatedTranslation.v[2] + tf.translation.v[2];
+		pose.vecWorldFromDriverTranslation[0] = tf.scale * rotatedTranslation.v[0] + tf.translation.v[0];
+		pose.vecWorldFromDriverTranslation[1] = tf.scale * rotatedTranslation.v[1] + tf.translation.v[1];
+		pose.vecWorldFromDriverTranslation[2] = tf.scale * rotatedTranslation.v[2] + tf.translation.v[2];
 	}
 	return true;
 }

--- a/OpenVR-SpaceCalibratorDriver/ServerTrackedDeviceProvider.h
+++ b/OpenVR-SpaceCalibratorDriver/ServerTrackedDeviceProvider.h
@@ -46,6 +46,7 @@ private:
 		bool enabled = false;
 		vr::HmdVector3d_t translation;
 		vr::HmdQuaternion_t rotation;
+		double scale;
 	};
 
 	DeviceTransform transforms[vr::k_unMaxTrackedDeviceCount];

--- a/Protocol.h
+++ b/Protocol.h
@@ -10,7 +10,7 @@
 
 namespace protocol
 {
-	const uint32_t Version = 1;
+	const uint32_t Version = 2;
 
 	enum RequestType
 	{
@@ -37,20 +37,28 @@ namespace protocol
 		bool enabled;
 		bool updateTranslation;
 		bool updateRotation;
+		bool updateScale;
 		vr::HmdVector3d_t translation;
 		vr::HmdQuaternion_t rotation;
+		double scale;
 
 		SetDeviceTransform(uint32_t id, bool enabled) :
-			openVRID(id), enabled(enabled), updateTranslation(false), updateRotation(false) { }
+			openVRID(id), enabled(enabled), updateTranslation(false), updateRotation(false), updateScale(false) { }
 
 		SetDeviceTransform(uint32_t id, bool enabled, vr::HmdVector3d_t translation) :
-			openVRID(id), enabled(enabled), updateTranslation(true), updateRotation(false), translation(translation) { }
+			openVRID(id), enabled(enabled), updateTranslation(true), updateRotation(false), updateScale(false), translation(translation) { }
 
 		SetDeviceTransform(uint32_t id, bool enabled, vr::HmdQuaternion_t rotation) :
-			openVRID(id), enabled(enabled), updateTranslation(false), updateRotation(true), rotation(rotation) { }
+			openVRID(id), enabled(enabled), updateTranslation(false), updateRotation(true), updateScale(false), rotation(rotation) { }
+
+		SetDeviceTransform(uint32_t id, bool enabled, double scale) :
+			openVRID(id), enabled(enabled), updateTranslation(false), updateRotation(false), updateScale(true), scale(scale) { }
 
 		SetDeviceTransform(uint32_t id, bool enabled, vr::HmdVector3d_t translation, vr::HmdQuaternion_t rotation) :
-			openVRID(id), enabled(enabled), updateTranslation(true), updateRotation(true), translation(translation), rotation(rotation) { }
+			openVRID(id), enabled(enabled), updateTranslation(true), updateRotation(true), updateScale(false), translation(translation), rotation(rotation) { }
+
+		SetDeviceTransform(uint32_t id, bool enabled, vr::HmdVector3d_t translation, vr::HmdQuaternion_t rotation, double scale) :
+			openVRID(id), enabled(enabled), updateTranslation(true), updateRotation(true), updateScale(true), translation(translation), rotation(rotation), scale(scale) { }
 	};
 
 	struct Request


### PR DESCRIPTION
Per the conversation at https://github.com/pushrax/OpenVR-SpaceCalibrator/issues/23#issuecomment-783644383, I thought I would take a crack at the scale parameter of the reference spaces being different.

What this **does** do:
 * Allows the driver to take the scale parameter over IPC
 * Applies it to the Pose
 * Serializes/deserializes the scale to/from stored config 
 * Allows user to edit scale from editor

What this **does not** do:
 * Determine the scale via calibration

Bonus goals: gives me familiarity with the code base and confirm this feature is still desired.

cc @pushrax 